### PR TITLE
Enhance Visura with OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ python run_amaf.py examples/sample_finqa.json
   prompt template resides in `amaf/prompts/tabu_synth.txt`.
 - **Contextron**: Extracts contextual metadata (e.g., titles, notes, captions). The
   prompt template resides in `amaf/prompts/contextron.txt`.
-- **Visura**: Converts visual cues (e.g., color/bold/highlight) to semantic tags.
+- **Visura**: Converts visual cues to semantic tags.  It now also accepts an
+  `image_path` and performs OCR before summarising the visual.
   The prompt template resides in `amaf/prompts/visura.txt`.
 - **TrendAnalyser**: Spots the two most important numeric trends.
   The prompt template resides in `amaf/prompts/trend_analyser.txt`.

--- a/amaf/agents/visura.py
+++ b/amaf/agents/visura.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 from typing import Any, Dict
+from PIL import Image
+import pytesseract
 
 from ..core import AgentOutput, InputData
 from .base import Agent
@@ -19,15 +21,28 @@ class VisuraAgent(Agent):
 
     # ── main run ────────────────────────────────────────────────────────
     def run(self, data: InputData, logs: Dict[str, Any]) -> AgentOutput:
-        # 1. Early exit if no visual cues
-        if not data.image_cues:
+        """Convert an image to text with OCR and summarise it."""
+
+        # 1. Determine visual text either from provided cues or via OCR
+        ocr_text = ""
+        image_text = data.image_cues.strip()
+
+        if not image_text and data.image_path:
+            try:
+                img = Image.open(data.image_path)
+                ocr_text = pytesseract.image_to_string(img)
+                image_text = ocr_text.strip()
+            except Exception:
+                image_text = ""
+
+        if not image_text:
             out = AgentOutput(cot="(no visuals)", result="")
             logs[self.name] = out.__dict__
             return out
 
         # 2. Build prompt from external template
         prompt_template = PROMPT_FILE.read_text(encoding="utf-8")
-        prompt = prompt_template.format(image_cues=data.image_cues)
+        prompt = prompt_template.format(image_cues=image_text)
 
         cot_and_msg = self._chat(prompt, temperature=0.3)
 
@@ -41,5 +56,5 @@ class VisuraAgent(Agent):
 
         # 5. Package result
         out = AgentOutput(cot=cot.strip(), result=msg.strip())
-        logs[self.name] = out.__dict__ | {"raw": cot_and_msg}
+        logs[self.name] = out.__dict__ | {"raw": cot_and_msg, "ocr": ocr_text}
         return out

--- a/amaf/core.py
+++ b/amaf/core.py
@@ -8,6 +8,7 @@ class InputData:
     table: Dict[str, Any]
     context: str = ""
     image_cues: str = ""
+    image_path: str = ""
     user_profile: str = "general"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ Jinja2>=3.1.3            # evaluate `when:` expressions in MCP
 python-dotenv>=1.0.0     # load OPENAI_API_KEY from .env
 rich>=13.7.0             # prettier CLI logging (if you enable it)
 tqdm>=4.66.2             # progress bars for batch runs
+pillow>=10.0.0           # image loading for OCR
+pytesseract>=0.3.10      # OCR engine


### PR DESCRIPTION
## Summary
- allow `InputData` to provide an optional `image_path`
- add OCR extraction to `VisuraAgent`
- mention new capability in README
- require Pillow and pytesseract

## Testing
- `pytest -q`
- `python test.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_685b644ab5d083229d8e9eb6ec4b05a6